### PR TITLE
Variable dx works in networks

### DIFF
--- a/examples/Basic1D-var-dx.py
+++ b/examples/Basic1D-var-dx.py
@@ -1,0 +1,79 @@
+#! /usr/bin/python3
+
+# Figure UpliftSubsidence in paper
+
+import numpy as np
+from matplotlib import pyplot as plt
+#plt.ion()
+
+import grlp
+
+Q = 700. # m3/s <-- mean annual @ Lago Argentino outlet, not bankfull
+#Q*= 5
+
+z0 = 180 # From modern surface near Lago Argentino outlet
+z1 = 0
+L = 250E3
+S0 = (z0-z1)/L
+B = 10000 # m: valley width, measured, approx uniform
+U = 1E-4 # m/yr: from terrace age and height above modern floodplain
+
+lp = grlp.LongProfile()
+self = lp
+
+self.bcr = z1
+
+lp.basic_constants()
+lp.bedload_lumped_constants()
+lp.set_hydrologic_constants()
+
+_x1 = np.linspace(0, 5000, 101)
+_x2 = np.arange(_x1[-1]+1000, 250001, 10000)
+_x = np.hstack( [_x1, _x2] )
+
+#lp.set_x(dx=1000, nx=251, x0=0) # Uniform
+lp.set_x(_x)
+lp.set_z(S0=-S0, z1=z1)
+lp.set_Q(Q)
+lp.set_B(B)
+lp.set_niter()
+lp.set_z_bl(z1)
+
+# Initial sed supply is the slope that we prescribe
+Qs0 = lp.k_Qs * lp.Q[0] * S0**(7/6.)
+lp.set_Qs_input_upstream(Qs0)
+
+fig = plt.figure(figsize=(6,3))
+ax1 = fig.add_subplot(1,1,1)
+plt.xlabel('Downstream distance [km]', fontsize=14, fontweight='bold')
+plt.ylabel('Elevation [m]', fontsize=14, fontweight='bold')
+plt.tight_layout()
+
+# Let's try just comparing starting points
+#"""
+# Starting steady state
+lp.set_uplift_rate(U/3.15E7)
+lp.evolve_threshold_width_river(10, 1E14)
+ax1.plot(lp.x/1000., lp.z, color='k', alpha=1, linewidth=3)
+
+# Transient -- double sediment supply
+ts = 1000 # years
+nts = 50
+lp.set_Qs_input_upstream(Qs0*4)
+for i in range(nts):
+    lp.evolve_threshold_width_river(1, ts * 3.15E7)
+    #ax1.plot(lp.x/1000., lp.z, color='r', alpha=1-0.75/nts*i, linewidth=1)
+    ax1.plot(lp.x/1000., lp.z, color='b', alpha=0.1, linewidth=1)
+ax1.plot(lp.x/1000., lp.z, color='b', alpha=1, linewidth=3)
+
+# Transient -- sediment supply to 0
+lp.set_Qs_input_upstream(0)
+for i in range(nts):
+    lp.evolve_threshold_width_river(1, ts * 3.15E7)
+    #ax1.plot(lp.x/1000., lp.z, color='r', alpha=1-0.75/nts*i, linewidth=1)
+    ax1.plot(lp.x/1000., lp.z, color='r', alpha=0.1, linewidth=1)
+ax1.plot(lp.x/1000., lp.z, color='r', alpha=1, linewidth=3)
+
+plt.show()
+#"""
+

--- a/examples/Basic1D.py
+++ b/examples/Basic1D.py
@@ -44,6 +44,12 @@ plt.xlabel('Downstream distance [km]', fontsize=14, fontweight='bold')
 plt.ylabel('Elevation [m]', fontsize=14, fontweight='bold')
 plt.tight_layout()
 
+# Evolve for 1 year
+lp.set_uplift_rate(U/3.15E7)
+lp.evolve_threshold_width_river(1, 1*3.15E7)
+
+# Let's try just comparing starting points
+#"""
 # Starting steady state
 lp.set_uplift_rate(U/3.15E7)
 lp.evolve_threshold_width_river(10, 1E14)
@@ -52,7 +58,7 @@ ax1.plot(lp.x/1000., lp.z, color='k', alpha=1, linewidth=3)
 # Transient -- double sediment supply
 ts = 1000 # years
 nts = 50
-lp.set_Qs_input_upstream(Qs0*2)
+lp.set_Qs_input_upstream(Qs0*4)
 for i in range(nts):
     lp.evolve_threshold_width_river(1, ts * 3.15E7)
     #ax1.plot(lp.x/1000., lp.z, color='r', alpha=1-0.75/nts*i, linewidth=1)
@@ -68,4 +74,5 @@ for i in range(nts):
 ax1.plot(lp.x/1000., lp.z, color='r', alpha=1, linewidth=3)
 
 plt.show()
+#"""
 

--- a/grlp/grlp.py
+++ b/grlp/grlp.py
@@ -792,9 +792,17 @@ class Network(object):
                 row = self.block_start_absolute[self.IDs == lp.ID][0]
                 # Matrix entry, assuming net aligns with ids
                 upseg = self.list_of_LongProfile_objects[ID]
+                # OLD
+                #C0 = upseg.k_Qs * upseg.intermittency \
+                #        / ((1-upseg.lambda_p) * upseg.sinuosity**(7/6.)) \
+                #        * self.dt / (2 * lp.dx_ext[0])
+                # !!!C0!!!
+                # I've updated dx_ext_2cell to acknowledge boundaries
+                # This should therefore be used here.
                 C0 = upseg.k_Qs * upseg.intermittency \
                         / ((1-upseg.lambda_p) * upseg.sinuosity**(7/6.)) \
-                        * self.dt / (2 * lp.dx_ext[0])
+                        * self.dt / lp.dx_ext_2cell[0]
+                # From earlier
                 #C0 = upseg.C0[-1] # Should be consistent
                 dzdx_0_16 = ( np.abs(lp.z_ext[1] - lp.z_ext[0])
                               / (lp.dx_ext[0]))**(1/6.)
@@ -810,9 +818,16 @@ class Network(object):
                 row = self.block_end_absolute[self.IDs == lp.ID][0]
                 # Matrix entry, assuming net aligns with ids
                 downseg = self.list_of_LongProfile_objects[ID]
+                # OLD
+                #C0 = downseg.k_Qs * downseg.intermittency \
+                #        / ((1-downseg.lambda_p) * downseg.sinuosity**(7/6.)) \
+                #        * self.dt / (2 * lp.dx_ext[-1])
+                # !!!C0!!!
+                # I've updated dx_ext_2cell to acknowledge boundaries
+                # This should therefore be used here.
                 C0 = downseg.k_Qs * downseg.intermittency \
                         / ((1-downseg.lambda_p) * downseg.sinuosity**(7/6.)) \
-                        * self.dt / (2 * lp.dx_ext[-1])
+                        * self.dt / lp.dx_ext_2cell[-1]
                 dzdx_0_16 = ( np.abs(lp.z_ext[-2] - lp.z_ext[-1])
                               / (lp.dx_ext[0]))**(1/6.)
                 C1 = C0 * dzdx_0_16 * lp.Q[-1] / downseg.B[0]

--- a/grlp/grlp.py
+++ b/grlp/grlp.py
@@ -113,6 +113,10 @@ class LongProfile(object):
                                       [self.x[-1] + self.dx[-1]] ] )
             self.dx_ext = np.diff(self.x_ext)
             self.dx_ext_2cell = self.x_ext[2:] - self.x_ext[:-2]
+            # LCR
+            self.dx_ext_2cell__left = self.dx_ext[:-1] - self.dx_ext_2cell
+            self.dx_ext_2cell__cent = self.dx_ext[:-1] - self.dx_ext[1:]
+            self.dx_ext_2cell__right = self.dx_ext[1:] - self.dx_ext_2cell
         elif x_ext is not None:
             self.x_ext = np.array(x_ext)
             self.x = x_ext[1:-1]
@@ -120,6 +124,10 @@ class LongProfile(object):
             self.dx_ext_2cell = self.x_ext[2:] - self.x_ext[:-2]
             self.dx_2cell = self.x[2:] - self.x[:-2]
             self.dx = np.diff(self.x)
+            # LCR
+            self.dx_ext_2cell__left = self.dx_ext[:-1] - self.dx_ext_2cell
+            self.dx_ext_2cell__cent = self.dx_ext[:-1] - self.dx_ext[1:]
+            self.dx_ext_2cell__right = self.dx_ext[1:] - self.dx_ext_2cell
         elif (dx is not None) and (nx is not None) and (x0 is not None):
             self.x = np.arange(x0, x0+dx*nx, dx)
             self.x_ext = np.arange(x0-dx, x0+dx*(nx+1), dx)
@@ -127,6 +135,10 @@ class LongProfile(object):
             self.dx_ext = dx * np.ones(len(self.x) + 1)
             self.dx_2cell = np.ones(len(self.x) - 1)
             self.dx_ext_2cell = self.x_ext[2:] - self.x_ext[:-2]
+            # LCR. Though could go to a simpler grid with dx here, really
+            self.dx_ext_2cell__left = self.dx_ext[:-1] - self.dx_ext_2cell
+            self.dx_ext_2cell__cent = self.dx_ext[:-1] - self.dx_ext[1:]
+            self.dx_ext_2cell__right = self.dx_ext[1:] - self.dx_ext_2cell
         else:
             sys.exit("Need x OR x_ext OR (dx, nx, x0)")
         self.nx = len(self.x)


### PR DESCRIPTION
The real solution here is to change, e.g., `2 * lp.dx_ext[-1]` to, e.g., `lp.dx_ext_2cell[-1]`, in https://github.com/MNiMORPH/GRLP/commit/1c46ca6e7fccf69fe6fe6509770c801d5661efd0. The latter was changed in https://github.com/MNiMORPH/GRLP/commit/f2a40eb8c7f73270fec4af3028c14d9fc42340f1 and https://github.com/MNiMORPH/GRLP/commit/7b155ac314ab8ec2354845cb18c3818aa82687bc.

This currently only averages upstream --> downstream. The next step is to balance this in constructing `dx_ext` and `dx_ext_2cell`.

All of the other work that I did to separate out `dx_ext_2cell` from `C0` (https://github.com/MNiMORPH/GRLP/commit/3e2aa56e03a9660204e8d36802ad1b71f52374cb) was ultimately unnecessary, though I may want to return to it to create a better approximation of the gradients. Right now, it approximates at the midpoint, which might be quite different from the gradient at the actual point, especially if there is significant curvature to the long profile that affects the length scale of individual segments. Right now, we might just need more points in the array to solve it appropriately.